### PR TITLE
support: librealsense: ignore checksum for pre-release tarball

### DIFF
--- a/recipes-support/librealsense/librealsense_0.9.2.bb
+++ b/recipes-support/librealsense/librealsense_0.9.2.bb
@@ -1,8 +1,8 @@
 require librealsense.inc
 
+BB_STRICT_CHECKSUM="0"
+
 SRC_URI = "https://github.com/IntelRealSense/librealsense/archive/v${PV}.tar.gz"
-SRC_URI[md5sum] = "6fdc1ca62ae8aeda2ece35283c47fef5"
-SRC_URI[sha256sum] = "945a7b1b1500a93678f9e52801f7611c003735038ad3d9bceabcb8ac8d07142f"
 
 PR = "r0"
 


### PR DESCRIPTION
librealsense tarball is continually changing because it is a
pre-release version, it seems like checksum change will continually
break the recipe, so instead ignore it until a final release is
published.

Signed-off-by: Omar Ramirez Luna omar.r.ramirez.luna@intel.com
